### PR TITLE
Include the `select-auth` command in authentication setup instructions

### DIFF
--- a/README.md
+++ b/README.md
@@ -121,8 +121,26 @@ Google account you want to authenticate with:
 $ slack external-auth add
 ```
 
-Once you've successfully connected your account, you're ready to configure your
-Google Sheet and create a link into your workflow!
+Once you've successfully authenticated your account, you're almost ready to
+configure your Google Sheet and create a link into your workflow!
+
+#### Assign Authentication to the Workflow
+
+To complete the connection process, you need to let your app know which
+authenticated account you'll be using for specific workflows.
+
+Specify that the "Collect billable hours" workflow should use your recently
+authenticated account when making API calls using the following command:
+
+```sh
+$ slack external-auth select-auth
+```
+
+Select the workspace and app environment for your app, then select the
+`#/workflows/collect_hours` workflow and the `google` provider to choose the
+external account to use.
+
+With this, you're ready to make API calls from your workflow!
 
 ### Create a Google Sheet
 


### PR DESCRIPTION
### Type of change

- [ ] New sample
- [ ] New feature
- [ ] Bug fix
- [x] Documentation

### Summary

This PR adds the `external-auth select-auth` command as part of the authentication instructions to complete the external authentication process.

### Requirements

- [x] I’ve checked my submission against the Samples Checklist to ensure it complies with all standards
- [x] I have ensured the changes I am contributing align with existing patterns and have tested and linted my code
- [x] I've read and agree to the [Code of Conduct](https://slackhq.github.io/code-of-conduct)
