### PR TITLE
Include profile information of the logging user in the spreadsheet

### DIFF
--- a/README.md
+++ b/README.md
@@ -158,7 +158,7 @@ To prepare this external datastore, start by
 using your authenticated account, then add the following headers to Row 1:
 
 ```
-Employee | Time in | Time out | Breaks (min) | Hours
+Name | Employee | Time in | Time out | Breaks (min) | Hours
 ```
 
 Designate this spreadsheet as the desired datastore through environment

--- a/README.md
+++ b/README.md
@@ -3,7 +3,7 @@
 This automation features a workflow that collects input from a form in Slack and
 saves the results to a Google Sheet.
 
-https://user-images.githubusercontent.com/18134219/214685659-c48d0e5e-af02-4f11-ba9a-5d2857f1fb5d.mov
+https://github.com/slack-samples/deno-timesheet-approval/assets/18134219/75224918-67fb-488a-8fa6-1e9af5f36de6
 
 **Guide Outline**:
 

--- a/functions/save_hours.ts
+++ b/functions/save_hours.ts
@@ -2,7 +2,7 @@ import { DefineFunction, Schema, SlackFunction } from "deno-slack-sdk/mod.ts";
 
 // Configuration information for the storing spreadsheet
 // https://developers.google.com/sheets/api/guides/concepts#expandable-1
-const GOOGLE_SPREADSHEET_RANGE = "A2:E2";
+const GOOGLE_SPREADSHEET_RANGE = "A2:F2";
 
 /**
  * Functions are reusable building blocks of automation that accept
@@ -70,6 +70,13 @@ export default SlackFunction(
       return { error: `Break time exceeds shift duration` };
     }
 
+    // Collect employee information
+    const user = await client.users.profile.get({ user: employee });
+    if (!user.ok) {
+      return { error: `Failed to gather employee profile: ${user.error}` };
+    }
+    const name = user.profile.real_name;
+
     // Collect Google access token
     const auth = await client.apps.auth.external.get({
       external_token_id: inputs.googleAccessTokenId,
@@ -90,7 +97,7 @@ export default SlackFunction(
       body: JSON.stringify({
         range: GOOGLE_SPREADSHEET_RANGE,
         majorDimension: "ROWS",
-        values: [[employee, startDate, endDate, timeOff, hours]],
+        values: [[name, employee, startDate, endDate, timeOff, hours]],
       }),
     });
 

--- a/functions/save_hours.ts
+++ b/functions/save_hours.ts
@@ -71,7 +71,7 @@ export default SlackFunction(
     }
 
     // Collect Google access token
-    const auth = await client.apiCall("apps.auth.external.get", {
+    const auth = await client.apps.auth.external.get({
       external_token_id: inputs.googleAccessTokenId,
     });
 

--- a/functions/save_hours_test.ts
+++ b/functions/save_hours_test.ts
@@ -6,6 +6,15 @@ import SaveHoursFunction from "./save_hours.ts";
 // Replaces globalThis.fetch with the mocked copy
 mf.install();
 
+mf.mock("POST@/api/users.profile.get", () => {
+  return new Response(JSON.stringify({
+    ok: true,
+    profile: {
+      real_name: "Cactus Poke",
+    },
+  }));
+});
+
 mf.mock("POST@/api/apps.auth.external.get", async (args) => {
   const body = await args.formData();
 

--- a/manifest.ts
+++ b/manifest.ts
@@ -14,5 +14,8 @@ export default Manifest({
   workflows: [CollectHoursWorkflow],
   externalAuthProviders: [GoogleProvider],
   outgoingDomains: ["sheets.googleapis.com"],
-  botScopes: ["commands"],
+  botScopes: [
+    "commands",
+    "users.profile:read",
+  ],
 });


### PR DESCRIPTION
### Type of change

- [ ] New sample
- [x] New feature
- [ ] Bug fix
- [ ] Documentation

### Summary

This PR adds an API call to [`users.profile.get`](https://api.slack.com/methods/users.profile.get) to retrieve the `real_name` of the logging user, and adds this to the spreadsheet!

### Requirements

- [x] I’ve checked my submission against the Samples Checklist to ensure it complies with all standards
- [x] I have ensured the changes I am contributing align with existing patterns and have tested and linted my code
- [x] I've read and agree to the [Code of Conduct](https://slackhq.github.io/code-of-conduct)
