### PR TITLE
chore: update Deno imports to use JSR

### DIFF
--- a/deno.jsonc
+++ b/deno.jsonc
@@ -30,8 +30,9 @@
     "test": "deno fmt --check && deno lint && deno test --allow-read"
   },
   "imports": {
-    "deno-slack-sdk/": "https://deno.land/x/deno_slack_sdk@2.15.1/",
-    "deno-slack-api/": "https://deno.land/x/deno_slack_api@2.8.0/",
+    "@slack/api": "jsr:@slack/api@2.9.0",
+    "@slack/sdk": "jsr:@slack/sdk@2.15.2-dev.1",
+
     "@std/dotenv": "jsr:@std/dotenv@^0.225.5",
     "@std/assert": "jsr:@std/assert@^1.0.15",
     "@std/testing": "jsr:@std/testing@^1.0.16"

--- a/deno.jsonc
+++ b/deno.jsonc
@@ -31,7 +31,7 @@
   },
   "imports": {
     "@slack/api": "jsr:@slack/api@2.9.0",
-    "@slack/sdk": "jsr:@slack/sdk@2.15.2-dev.1",
+    "@slack/sdk": "jsr:@slack/sdk@2.15.2",
 
     "@std/dotenv": "jsr:@std/dotenv@^0.225.5",
     "@std/assert": "jsr:@std/assert@^1.0.15",

--- a/external_auth/google_provider.ts
+++ b/external_auth/google_provider.ts
@@ -1,4 +1,4 @@
-import { DefineOAuth2Provider, Schema } from "deno-slack-sdk/mod.ts";
+import { DefineOAuth2Provider, Schema } from "@slack/sdk";
 import "@std/dotenv/load";
 
 /**

--- a/functions/save_hours.ts
+++ b/functions/save_hours.ts
@@ -1,4 +1,4 @@
-import { DefineFunction, Schema, SlackFunction } from "deno-slack-sdk/mod.ts";
+import { DefineFunction, Schema, SlackFunction } from "@slack/sdk";
 
 // Configuration information for the storing spreadsheet
 // https://developers.google.com/sheets/api/guides/concepts#expandable-1

--- a/functions/save_hours_test.ts
+++ b/functions/save_hours_test.ts
@@ -1,5 +1,5 @@
 import { stub } from "@std/testing/mock";
-import { SlackFunctionTester } from "deno-slack-sdk/mod.ts";
+import { SlackFunctionTester } from "@slack/sdk";
 import { assertEquals } from "@std/assert";
 import SaveHoursFunction from "./save_hours.ts";
 

--- a/manifest.ts
+++ b/manifest.ts
@@ -1,4 +1,4 @@
-import { Manifest } from "deno-slack-sdk/mod.ts";
+import { Manifest } from "@slack/sdk";
 import CollectHoursWorkflow from "./workflows/collect_hours.ts";
 import GoogleProvider from "./external_auth/google_provider.ts";
 

--- a/triggers/collect_hours_trigger.ts
+++ b/triggers/collect_hours_trigger.ts
@@ -1,5 +1,5 @@
-import type { Trigger } from "deno-slack-sdk/types.ts";
-import { TriggerContextData, TriggerTypes } from "deno-slack-api/mod.ts";
+import type { Trigger } from "@slack/sdk/types.ts";
+import { TriggerContextData, TriggerTypes } from "@slack/api";
 import CollectHoursWorkflow from "../workflows/collect_hours.ts";
 
 /**

--- a/workflows/collect_hours.ts
+++ b/workflows/collect_hours.ts
@@ -1,4 +1,4 @@
-import { DefineWorkflow, Schema } from "deno-slack-sdk/mod.ts";
+import { DefineWorkflow, Schema } from "@slack/sdk";
 import { SaveHoursFunctionDefinition } from "../functions/save_hours.ts";
 
 /**


### PR DESCRIPTION
Updates deno-slack-sdk and deno-slack-api imports to use the new JSR packages (@slack/sdk and @slack/api).

Made with [Cursor](https://cursor.com)